### PR TITLE
Update dimensions when screen is resized

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -274,4 +274,10 @@ class Bin {
     g.endShape(CLOSE);
     g.pop();
   }
+
+  resize(newW) {
+    this.w = newW;
+    this.x = this.i * newW + newW * 0.5;
+    this.y = g.height - buffer * 0.75;    
+  }
 }

--- a/data.js
+++ b/data.js
@@ -6,12 +6,10 @@ class Data {
     this.x = x;
     this.y = y;
     this.color = palette.FG; //TODO: pass this in as arg rather than global variable?
-    this.alpha = 255;
     this.sz = baseSize;
     this.refined = false;
     this.binIt = false;
     this.bin = undefined;
-    this.binPause = 30;
   }
   
   refine(bin) {
@@ -23,17 +21,12 @@ class Data {
     // This is a band-aid
     if (this.bin) {
       this.bin.open();
-      if (this.binPause <= 0) {
-        const dx = this.bin.x - this.x;
-        const dy = this.bin.y - this.y;
-        let easing = map(abs(dy), this.bin.y, 0, 0.02, 0.1);
-        this.x += dx * easing;
-        this.y += max(dy * easing, -20);
-        this.alpha = map(this.y, this.homeY, this.bin.y, 255, 5);
-        this.bin.lastRefinedTime = millis();
-      } else {
-        this.binPause--;
-      }
+      let targetX = g.width / 2;
+      let targetY = g.height;
+      if (this.bin) this.x = lerp(this.x, this.bin.x, random(0, 0.2));
+      this.y = lerp(this.y, this.bin.y, random(0, 0.2));
+      this.x += random(-5, 5);
+      this.y += random(-5, 5);
       if (dist(this.x, this.y, this.bin.x, this.bin.y) < 2) {
         this.bin.addNumber();
         this.num = floor(random(10));
@@ -43,8 +36,6 @@ class Data {
         this.binIt = false;
         this.bin = undefined;
         this.color = palette.FG;
-        this.alpha = 255;
-        this.binPause = 30;
       }
     }
   }
@@ -74,14 +65,9 @@ class Data {
 
   show() {
     g.textFont('Courier');
-    // if the digit is ready to be binned, lerp to a large size proprtional to the pause time
-    const digitSize = this.binIt ? lerp(this.sz, baseSize * 2.5, map(this.binPause, 30, 0, 0, 1)) : this.sz;
-    g.textSize(digitSize);
+    g.textSize(this.sz);
     g.textAlign(CENTER, CENTER);
-    const col = color(this.color);
-    col.setAlpha(this.alpha);
-    g.fill(col);
-    g.stroke(col);
+    g.fill(this.color);
     
     g.text(this.num, this.x, this.y);
 

--- a/data.js
+++ b/data.js
@@ -6,28 +6,34 @@ class Data {
     this.x = x;
     this.y = y;
     this.color = palette.FG; //TODO: pass this in as arg rather than global variable?
+    this.alpha = 255;
     this.sz = baseSize;
     this.refined = false;
     this.binIt = false;
     this.bin = undefined;
+    this.binPause = 30;
   }
-
+  
   refine(bin) {
     this.binIt = true;
     this.bin = bin;
   }
-
+  
   goBin() {
     // This is a band-aid
     if (this.bin) {
       this.bin.open();
-
-      let targetX = g.width / 2;
-      let targetY = g.height;
-      if (this.bin) this.x = lerp(this.x, this.bin.x, random(0, 0.2));
-      this.y = lerp(this.y, this.bin.y, random(0, 0.2));
-      this.x += random(-5, 5);
-      this.y += random(-5, 5);
+      if (this.binPause <= 0) {
+        const dx = this.bin.x - this.x;
+        const dy = this.bin.y - this.y;
+        let easing = map(abs(dy), this.bin.y, 0, 0.02, 0.1);
+        this.x += dx * easing;
+        this.y += max(dy * easing, -20);
+        this.alpha = map(this.y, this.homeY, this.bin.y, 255, 5);
+        this.bin.lastRefinedTime = millis();
+      } else {
+        this.binPause--;
+      }
       if (dist(this.x, this.y, this.bin.x, this.bin.y) < 2) {
         this.bin.addNumber();
         this.num = floor(random(10));
@@ -37,6 +43,8 @@ class Data {
         this.binIt = false;
         this.bin = undefined;
         this.color = palette.FG;
+        this.alpha = 255;
+        this.binPause = 30;
       }
     }
   }
@@ -66,13 +74,24 @@ class Data {
 
   show() {
     g.textFont('Courier');
-    g.textSize(this.sz);
+    // if the digit is ready to be binned, lerp to a large size proprtional to the pause time
+    const digitSize = this.binIt ? lerp(this.sz, baseSize * 2.5, map(this.binPause, 30, 0, 0, 1)) : this.sz;
+    g.textSize(digitSize);
     g.textAlign(CENTER, CENTER);
-    g.fill(this.color);
+    const col = color(this.color);
+    col.setAlpha(this.alpha);
+    g.fill(col);
+    g.stroke(col);
+    
     g.text(this.num, this.x, this.y);
 
     // rectMode(CENTER);
     // noFill();
     // square(this.x, this.y, r);
+  }
+
+  resize(newX, newY) {
+    this.homeX = newX;
+    this.homeY = newY;
   }
 }

--- a/sketch.js
+++ b/sketch.js
@@ -430,7 +430,8 @@ function drawNumbers() {
     let xoff = 0;
     for (let j = 0; j < rows; j++) {
       let num = numbers[i + j * cols];
-
+      if (!num) return;
+      
       if (num.binIt) {
         num.goBin();
         num.show();
@@ -520,4 +521,36 @@ function toggleShader() {
     palette = shaderPalette;
   }
   useShader = !useShader;
+}
+
+function windowResized(ev) {
+  // TODO: lots of duplicated code from startOver, better to create something reusable
+  resizeCanvas(windowWidth, windowHeight);
+  g.resizeCanvas(windowWidth, windowHeight);
+  shaderLayer.resizeCanvas(windowWidth, windowHeight)
+  crtShader.setUniform('u_resolution', [g.width, g.height]);
+
+  smaller = min(g.width, g.height);
+
+  sharedImg.resize(smaller * 0.5, 0);
+  nopeImg.resize(smaller * 0.5, 0);
+  completedImg.resize(smaller * 0.5, 0);
+  
+  refined.forEach((bin) => bin.resize(g.width / refined.length));
+  
+  r = (smaller - buffer * 2) / 10;
+  baseSize = r * 0.33;
+   
+  cols = floor(g.width / r);
+  rows = floor((g.height - buffer * 2) / r);
+  let  wBuffer =  g.width - cols * r;
+  
+  for (let j = 0; j < rows; j++) {
+    for (let i = 0; i < cols; i++) {
+      let x = i * r + r * 0.5 + wBuffer * 0.5;
+      let y = j * r + r * 0.5 + buffer;
+      const numToUpdate = numbers[i + j * cols];
+      if (numToUpdate) numToUpdate.resize(x, y);
+    }
+  }
 }


### PR DESCRIPTION
addresses #4 

At the moment I'm duplicating a lot of code from the `setup` and `startOver` functions, so it could be implemented more nicely

There seems to be some strange behaviour when the screen is resized so width is less than the height. I've noticed on mobile there are many many more numbers than on desktop, perhaps that is something we address here or somewhere else

https://user-images.githubusercontent.com/17256474/166125393-a63353c1-0868-4254-9d5b-96a5bbde48e9.mp4

 