### PR TITLE
Draw cursor in style seen in show

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -363,6 +363,8 @@ function draw() {
   // image(mdeGIF, 0, 0);
   // pop();
 
+  drawCursor(mouseX, mouseY);
+
   if (useShader) {
     shaderLayer.rect(0, 0, g.width, g.height);
     shaderLayer.shader(crtShader);
@@ -377,6 +379,7 @@ function draw() {
   } else {
     image(g, 0, 0, g.width, g.height);
   }
+
 
   // Displays FPS in top left corner, helpful for debugging
   // drawFPS();
@@ -521,6 +524,26 @@ function toggleShader() {
     palette = shaderPalette;
   }
   useShader = !useShader;
+}
+
+function drawCursor(xPos, yPos) {
+  // prevents the cursor appearing in top left corner on page load
+  if (xPos == 0 && yPos == 0) return;
+  g.push()
+  // this offset makes the box draw from point of cursor 
+  g.translate(xPos+10, yPos+10);
+  g.scale(1.2);
+  g.fill(palette.BG);
+  g.stroke(palette.FG);
+  g.strokeWeight(3);
+  g.beginShape();
+  g.rotate(-PI/5);
+  g.vertex(0, -10);
+  g.vertex(7.5, 10);
+  g.vertex(0, 5);
+  g.vertex(-7.5, 10);
+  g.endShape(CLOSE);
+  g.pop();
 }
 
 function windowResized(ev) {

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ body {
 canvas {
   display: block;
   touch-action: none;
+  cursor: none;
 }
 
 div {


### PR DESCRIPTION
https://user-images.githubusercontent.com/17256474/166247169-fed34dbd-d9f0-414d-bdaf-e825af8b35e3.mp4

I've added a custom cursor as seen in the show. I hide the default cursor on `canvas` in the css, but show it in divs for the button overlay.

I also show the cursor on mobile, which I think is nice. However if we wanted to hide it we could do: 
```js
if (useShader) drawCursor(mouseX, mouseY);
```
or
```js
if (!isTouchScreenDevice()) drawCursor(mouseX, mouseY);
```

link to try: [https://macrodata-refinement-git-feature-draw-cursor-jhrtn.vercel.app](https://macrodata-refinement-git-feature-draw-cursor-jhrtn.vercel.app)

![Screenshot 2022-05-02 at 15 04 39](https://user-images.githubusercontent.com/17256474/166247371-4207ab3a-245b-46bc-b15a-8ff8f6f4bafd.png)
_cursor reference from show_