### PR TITLE
Keep track of time spent refining in local storage

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -175,8 +175,8 @@ function setup() {
       }
       thenumbers += '\n';
     }
-    const timeStr = completedTime.toLocaleString('en-US');
-    const msg = `In refining ${macrodataFile.coordinates} (${macrodataFile.fileName}) in ${timeStr} milliseconds I have brought glory to the company.
+    const timeStr = (secondsSpentRefining/60).toFixed(2).toLocaleString('en-US');
+    const msg = `In refining ${macrodataFile.coordinates} (${macrodataFile.fileName}) in ${timeStr} minutes I have brought glory to the company.
 Praise Kier.
 ${thenumbers}#mdrlumon #severance 🧇🐐🔢💯
 lumon-industries.com`;

--- a/sketch.js
+++ b/sketch.js
@@ -17,6 +17,7 @@ let refineTX, refinteTY, refineBX, refineBY;
 let lumon;
 
 let startTime = 0;
+let secondsSpentRefining = 0;
 
 const emojis = ['0️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣'];
 
@@ -99,6 +100,8 @@ function startOver(resetFile = false) {
 
   if (resetFile) {
     macrodataFile.resetFile();
+    storeItem('secondsSpentRefining', 0);
+    secondsSpentRefining = 0;
   }
 
   // Refinement bins
@@ -149,6 +152,7 @@ function setup() {
   smaller = min(g.width, g.height);
 
   macrodataFile = new MacrodataFile();
+  secondsSpentRefining = getItem('secondsSpentRefining') ?? 0;
 
   sharedImg.resize(smaller * 0.5, 0);
   nopeImg.resize(smaller * 0.5, 0);
@@ -376,6 +380,15 @@ function draw() {
     image(shaderLayer, 0, 0, g.width, g.height);
   } else {
     image(g, 0, 0, g.width, g.height);
+  }
+
+
+  if (focused) {
+    secondsSpentRefining += deltaTime / 1000;
+    const roundedTime = round(secondsSpentRefining);
+    if (roundedTime % 5 == 0 && roundedTime != getItem('secondsSpentRefining')) {
+      storeItem('secondsSpentRefining', round(roundedTime));
+    }
   }
 
   // Displays FPS in top left corner, helpful for debugging

--- a/sketch.js
+++ b/sketch.js
@@ -18,6 +18,7 @@ let lumon;
 
 let startTime = 0;
 let secondsSpentRefining = 0;
+let lastRefiningTimeStored = 0;
 
 const emojis = ['0️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣'];
 
@@ -102,6 +103,7 @@ function startOver(resetFile = false) {
     macrodataFile.resetFile();
     storeItem('secondsSpentRefining', 0);
     secondsSpentRefining = 0;
+    lastRefiningTimeStored = 0;
   }
 
   // Refinement bins
@@ -374,13 +376,13 @@ function draw() {
   if (focused) {
     secondsSpentRefining += deltaTime / 1000;
     const roundedTime = round(secondsSpentRefining);
-    if (roundedTime % 5 == 0 && roundedTime != getItem('secondsSpentRefining')) {
-      storeItem('secondsSpentRefining', round(roundedTime));
+    if (roundedTime % 5 == 0 && roundedTime != lastRefiningTimeStored) {
+      storeItem('secondsSpentRefining', roundedTime);
+      lastRefiningTimeStored = roundedTime;
     }
   }
 
   // Displays FPS in top left corner, helpful for debugging
-  // drawFPS();
 }
 
 function drawTop(percent) {

--- a/sketch.js
+++ b/sketch.js
@@ -390,7 +390,7 @@ function draw() {
     secondsSpentRefining += deltaTime / 1000;
     const roundedTime = round(secondsSpentRefining);
     if (roundedTime % 5 == 0 && roundedTime != lastRefiningTimeStored) {
-      storeItem('secondsSpentRefining', roundedTime);
+      storeItem('secondsSpentRefining', secondsSpentRefining);
       lastRefiningTimeStored = roundedTime;
     }
   }

--- a/sketch.js
+++ b/sketch.js
@@ -190,12 +190,6 @@ lumon-industries.com`;
     //}
   });
 
-  // for (let i = 0; i < 1; i++) {
-  //   loadImage('mde.gif', (img) => {
-  //     mdeGIF[i] = img;
-  //   });
-  // }
-
   startOver();
 }
 function mousePressed() {
@@ -360,12 +354,6 @@ function draw() {
       yoff += 5;
     }
   }
-  // push();
-  // imageMode(CENTER);
-  // translate(width * 0.5, height * 0.5);
-  // rotate(frameCount * 0.05);
-  // image(mdeGIF, 0, 0);
-  // pop();
 
   if (useShader) {
     shaderLayer.rect(0, 0, g.width, g.height);

--- a/sketch.js
+++ b/sketch.js
@@ -189,8 +189,8 @@ function setup() {
       }
       thenumbers += '\n';
     }
-    const timeStr = (secondsSpentRefining/60).toFixed(2).toLocaleString('en-US');
-    const msg = `In refining ${macrodataFile.coordinates} (${macrodataFile.fileName}) in ${timeStr} minutes I have brought glory to the company.
+    const timeStr = createTimeString(secondsSpentRefining);
+    const msg = `In refining ${macrodataFile.coordinates} (${macrodataFile.fileName}) in ${timeStr} I have brought glory to the company.
 Praise Kier.
 ${thenumbers}#mdrlumon #severance 🧇🐐🔢💯
 lumon-industries.com`;

--- a/utils.js
+++ b/utils.js
@@ -23,3 +23,7 @@ const isTouchScreenDevice = () => {
   }
   return hasTouchScreen;
 }
+// Takes a value in seconds, returns hh:mm:ss:ms
+const createTimeString = (seconds) => {
+  return new Date(seconds * 1000).toISOString().substring(11, 23);
+}

--- a/utils.js
+++ b/utils.js
@@ -25,5 +25,8 @@ const isTouchScreenDevice = () => {
 }
 // Takes a value in seconds, returns hh:mm:ss:ms
 const createTimeString = (seconds) => {
-  return new Date(seconds * 1000).toISOString().substring(11, 23);
+  const baseString = new Date(seconds * 1000).toISOString().substring(11, 23);
+  const hhmm = baseString.split(':');
+  const ssms = hhmm[2].split('.');
+  return `${hhmm[0]}h ${hhmm[1]}m ${ssms[0]}s ${ssms[1]}ms`;
 }


### PR DESCRIPTION
The current method of tracking the completed time gets reset if the page is refreshed.

This PR keeps track of the time spent refining (when the page is focused) and updates the value in local storage every 5 seconds.

I've updated the timeStr to be in minutes rather than milliseconds, but this could be changed as desired

```
In refining C03779:D3FCA5 (Narva) in 2.55 minutes I have brought glory to the company.
Praise Kier.
5️⃣5️⃣5️⃣6️⃣7️⃣
1️⃣8️⃣0️⃣6️⃣9️⃣
2️⃣9️⃣5️⃣7️⃣7️⃣
5️⃣8️⃣9️⃣5️⃣2️⃣
7️⃣7️⃣8️⃣9️⃣0️⃣
#mdrlumon #severance 🧇🐐🔢💯
lumon-industries.com
```