### PR TITLE
fix invalid Service Worker reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js"></script>
     <script>
-      navigator.serviceWorker.register?.('/sw.js').catch(() => {})
+      navigator.serviceWorker.register?.('/service-worker.js').catch(() => {})
     </script>
     <link rel="stylesheet" type="text/css" href="style.css" />
     <link rel="manifest" href="manifest.json" />


### PR DESCRIPTION
There was a little oversight in #47 😅.
The commit added the service worker in `service-worker.js`, but the script snippet in `index.html` attempts to load `sw.js`.

This PR addresses that and loads the correct file.